### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_page.make
+++ b/ding_page.make
@@ -16,7 +16,7 @@ projects[cache_actions][subdir] = "contrib"
 projects[cache_actions][version] = "2.0-alpha5"
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[features][subdir] = "contrib"
 projects[features][version] = "2.0"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.