### PR TITLE
Issue #287 - Move campaign panes to left column.

### DIFF
--- a/ding_page.pages_default.inc
+++ b/ding_page.pages_default.inc
@@ -201,7 +201,7 @@ function ding_page_default_page_manager_handlers() {
     $display->panels['main_content'][0] = 'new-33f78b6a-3147-455f-b437-70261fe3426c';
     $pane = new stdClass();
     $pane->pid = 'new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
-    $pane->panel = 'right_sidebar';
+    $pane->panel = 'left_sidebar';
     $pane->type = 'campaign';
     $pane->subtype = 'campaign';
     $pane->shown = TRUE;
@@ -234,10 +234,10 @@ function ding_page_default_page_manager_handlers() {
     $pane->locks = '';
     $pane->uuid = '0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
     $display->content['new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c'] = $pane;
-    $display->panels['right_sidebar'][0] = 'new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
+    $display->panels['left_sidebar'][0] = 'new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
     $pane = new stdClass();
     $pane->pid = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
-    $pane->panel = 'right_sidebar';
+    $pane->panel = 'left_sidebar';
     $pane->type = 'block';
     $pane->subtype = 'similarterms-ding_content_tags';
     $pane->shown = TRUE;
@@ -256,7 +256,7 @@ function ding_page_default_page_manager_handlers() {
     $pane->locks = '';
     $pane->uuid = '0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
     $display->content['new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6'] = $pane;
-    $display->panels['right_sidebar'][1] = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
+    $display->panels['left_sidebar'][1] = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
   $display->hide_title = PANELS_TITLE_PANE;
   $display->title_pane = 'new-33f78b6a-3147-455f-b437-70261fe3426c';
   $handler->conf['display'] = $display;

--- a/ding_page.pages_default.inc
+++ b/ding_page.pages_default.inc
@@ -230,11 +230,11 @@ function ding_page_default_page_manager_handlers() {
     );
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 0;
+    $pane->position = 3;
     $pane->locks = '';
     $pane->uuid = '0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
     $display->content['new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c'] = $pane;
-    $display->panels['left_sidebar'][0] = 'new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
+    $display->panels['left_sidebar'][3] = 'new-0c1b010b-aad2-4a5e-badd-f2fe5334a80c';
     $pane = new stdClass();
     $pane->pid = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
     $pane->panel = 'left_sidebar';
@@ -252,11 +252,11 @@ function ding_page_default_page_manager_handlers() {
     );
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 1;
+    $pane->position = 4;
     $pane->locks = '';
     $pane->uuid = '0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
     $display->content['new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6'] = $pane;
-    $display->panels['left_sidebar'][1] = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
+    $display->panels['left_sidebar'][4] = 'new-0d732c8e-6a2e-4993-ba6f-7cb2025bada6';
   $display->hide_title = PANELS_TITLE_PANE;
   $display->title_pane = 'new-33f78b6a-3147-455f-b437-70261fe3426c';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
Within the task of refactoring the [`ding_campaign`](https://github.com/ding2/ding_campaign) module, it has been discovered that the current campaign panes is located in the right side of the layout on several panels.

Even though the module is not activated/working in DDB CMS, the panes are added as inaccessible on the layouts which means that if someone should activate the module, the layout will be broken due to the narrow middle column.

Issue: http://platform.dandigbib.org/issues/287.
